### PR TITLE
adjust mnemonic popup: change from placement='right' to 'right end'

### DIFF
--- a/src/Components/Watcher/MnemonicPopUp.tsx
+++ b/src/Components/Watcher/MnemonicPopUp.tsx
@@ -8,7 +8,11 @@ type PropTypes = {
 
 const MnemonicPopUp = ({ triggerValue, data }: PropTypes) => {
   return (
-    <RuxPopUp placement="right" className="mnemonic-pop-up">
+    <RuxPopUp
+      placement="right-end"
+      strategy="fixed"
+      className="mnemonic-pop-up"
+    >
       <RuxCard>
         <span slot="header">{data.mnemonicId}</span>
         <div>

--- a/src/Components/Watcher/Watcher.css
+++ b/src/Components/Watcher/Watcher.css
@@ -81,10 +81,16 @@
 
 rux-pop-up.mnemonic-pop-up span[slot="trigger"] {
   color: var(--color-text-interactive-default);
+  display: inline-block;
 }
 
 rux-pop-up.mnemonic-pop-up span[slot="trigger"]:hover {
   border-bottom: 1px solid var(--color-text-interactive-default);
+}
+
+rux-pop-up.mnemonic-pop-up rux-card::part(container) {
+  border-width: 0px;
+  box-shadow: none;
 }
 
 rux-pop-up.mnemonic-pop-up rux-card::part(body) {


### PR DESCRIPTION
Made this change and a couple of small styling changes. The placement change is because setting it to just 'right' doesn't seem to allow it to adjust upward and downward but setting it to right-end or right-start will make the poopup adjust so that it is never flows off the screen. Also changed the trigger to inline-block because inline display wasn't allowing the arrow the space it needed.