### PR TITLE
suggestion: theme toggle

### DIFF
--- a/src/Components/GlobalStatusBar.css
+++ b/src/Components/GlobalStatusBar.css
@@ -7,7 +7,7 @@
 }
 
 rux-menu-item[value="themeToggle"] span {
-  display: flex;
+  display: flex; 
   gap: var(--spacing-2);
   align-items: center;
 }

--- a/src/Components/GlobalStatusBar.css
+++ b/src/Components/GlobalStatusBar.css
@@ -5,3 +5,9 @@
 .status-indicators rux-monitoring-icon {
   margin-inline: var(--spacing-3);
 }
+
+rux-menu-item[value="themeToggle"] span {
+  display: flex;
+  gap: var(--spacing-2);
+  align-items: center;
+}

--- a/src/Components/GlobalStatusBar.tsx
+++ b/src/Components/GlobalStatusBar.tsx
@@ -7,7 +7,6 @@ import {
   RuxMenu,
   RuxMenuItem,
   RuxMonitoringIcon,
-  RuxTooltip,
   RuxNotification,
 } from "@astrouxds/react";
 import type { Status } from "@astrouxds/mock-data";
@@ -91,50 +90,44 @@ const GlobalStatusBar = () => {
         <RuxClock />
 
         <div className="status-indicators" slot="right-side">
-          <RuxTooltip message={`Ground ${notifications1}`} placement="bottom">
-            <RuxPopUp placement="bottom" closeOnSelect>
-              <RuxMenu onRuxmenuselected={() => setOpenBanner(true)}>
-                <RuxMenuItem>Investigate</RuxMenuItem>
-              </RuxMenu>
-              <RuxMonitoringIcon
-                status={status1}
-                icon="antenna-off"
-                label="Ground"
-                notifications={notifications1}
-                slot="trigger"
-              ></RuxMonitoringIcon>
-            </RuxPopUp>
-          </RuxTooltip>
+          <RuxPopUp placement="bottom" closeOnSelect>
+            <RuxMenu onRuxmenuselected={() => setOpenBanner(true)}>
+              <RuxMenuItem>Investigate</RuxMenuItem>
+            </RuxMenu>
+            <RuxMonitoringIcon
+              status={status1}
+              icon="antenna-off"
+              label="Ground"
+              notifications={notifications1}
+              slot="trigger"
+            ></RuxMonitoringIcon>
+          </RuxPopUp>
 
-          <RuxTooltip message={`Comms ${notifications2}`} placement="bottom">
-            <RuxPopUp placement="bottom" closeOnSelect>
-              <RuxMenu onRuxmenuselected={() => setOpenBanner(true)}>
-                <RuxMenuItem>Investigate</RuxMenuItem>
-              </RuxMenu>
-              <RuxMonitoringIcon
-                status={status2}
-                icon="antenna-receive"
-                label="Comms"
-                notifications={notifications2}
-                slot="trigger"
-              />
-            </RuxPopUp>
-          </RuxTooltip>
+          <RuxPopUp placement="bottom" closeOnSelect>
+            <RuxMenu onRuxmenuselected={() => setOpenBanner(true)}>
+              <RuxMenuItem>Investigate</RuxMenuItem>
+            </RuxMenu>
+            <RuxMonitoringIcon
+              status={status2}
+              icon="antenna-receive"
+              label="Comms"
+              notifications={notifications2}
+              slot="trigger"
+            />
+          </RuxPopUp>
 
-          <RuxTooltip message={`Software ${notifications3}`} placement="bottom">
-            <RuxPopUp placement="bottom" closeOnSelect>
-              <RuxMenu onRuxmenuselected={() => setOpenBanner(true)}>
-                <RuxMenuItem>Investigate</RuxMenuItem>
-              </RuxMenu>
-              <RuxMonitoringIcon
-                status={status3}
-                icon="processor"
-                label="Software"
-                notifications={notifications3}
-                slot="trigger"
-              />
-            </RuxPopUp>
-          </RuxTooltip>
+          <RuxPopUp placement="bottom" closeOnSelect>
+            <RuxMenu onRuxmenuselected={() => setOpenBanner(true)}>
+              <RuxMenuItem>Investigate</RuxMenuItem>
+            </RuxMenu>
+            <RuxMonitoringIcon
+              status={status3}
+              icon="processor"
+              label="Software"
+              notifications={notifications3}
+              slot="trigger"
+            />
+          </RuxPopUp>
         </div>
       </RuxGlobalStatusBar>
     </>

--- a/src/Components/GlobalStatusBar.tsx
+++ b/src/Components/GlobalStatusBar.tsx
@@ -11,7 +11,6 @@ import {
 } from "@astrouxds/react";
 import type { Status } from "@astrouxds/mock-data";
 import "./GlobalStatusBar.css";
-import { RuxMenuCustomEvent } from "@astrouxds/astro-web-components";
 
 const GlobalStatusBar = () => {
   const [status1, setStatus1] = useState<Status>("off");
@@ -53,8 +52,9 @@ const GlobalStatusBar = () => {
     return () => clearInterval(interval);
   });
 
-  function menuSelect(e: RuxMenuCustomEvent<HTMLRuxMenuItemElement>) {
-    if (e.detail.value === "themeToggle") {
+  function menuSelect(e: CustomEvent) {
+    const { detail } = e;
+    if (detail.value === "themeToggle") {
       setLightTheme(!lightTheme);
       document.body.classList.toggle("light-theme");
       return;

--- a/src/Components/GlobalStatusBar.tsx
+++ b/src/Components/GlobalStatusBar.tsx
@@ -12,6 +12,7 @@ import {
 } from "@astrouxds/react";
 import type { Status } from "@astrouxds/mock-data";
 import "./GlobalStatusBar.css";
+import { RuxMenuCustomEvent } from "@astrouxds/astro-web-components";
 
 const GlobalStatusBar = () => {
   const [status1, setStatus1] = useState<Status>("off");
@@ -20,6 +21,7 @@ const GlobalStatusBar = () => {
   const [notifications1, setNotifications1] = useState(0);
   const [notifications2, setNotifications2] = useState(2);
   const [notifications3, setNotifications3] = useState(4);
+  const [lightTheme, setLightTheme] = useState(false);
   const [openBanner, setOpenBanner] = useState(false);
 
   const statusValuesArr = [
@@ -52,6 +54,15 @@ const GlobalStatusBar = () => {
     return () => clearInterval(interval);
   });
 
+  function menuSelect(e: RuxMenuCustomEvent<HTMLRuxMenuItemElement>) {
+    if (e.detail.value === "themeToggle") {
+      setLightTheme(!lightTheme);
+      document.body.classList.toggle("light-theme");
+      return;
+    }
+    setOpenBanner(true);
+  }
+
   return (
     <>
       <RuxNotification
@@ -69,7 +80,10 @@ const GlobalStatusBar = () => {
       >
         <RuxPopUp placement="top-start" slot="left-side" closeOnSelect>
           <RuxIcon slot="trigger" size="small" icon="apps" />
-          <RuxMenu onRuxmenuselected={() => setOpenBanner(true)}>
+          <RuxMenu onRuxmenuselected={(e) => menuSelect(e)}>
+            <RuxMenuItem value="themeToggle">
+              {lightTheme ? "Dark" : "Light"} Theme
+            </RuxMenuItem>
             <RuxMenuItem>Preferences</RuxMenuItem>
             <RuxMenuItem>Sign Out</RuxMenuItem>
           </RuxMenu>


### PR DESCRIPTION
Feel free to say no but since these will eventually be samples for clients it was pretty low hanging fruit to add a theme toggle. It is in the GSB menu. I can put it elsewhere or make it a switch instead but this was the least disruptive to the layout.

Oh while I was in here I removed the tooltips on the icons in the GSB, it was covering the popup and replaying the same info as the icon so I thought not was not terribly necessary.. I can switch it back if needed. :)