### PR TITLE
recommendation: change filter banner from a notification

### DIFF
--- a/src/Components/Alerts/Alerts.css
+++ b/src/Components/Alerts/Alerts.css
@@ -24,6 +24,18 @@
   gap: 5%;
 }
 
+.filter-notification {
+  background-color: var(--color-background-surface-default);
+  padding: var(--spacing-2);
+  overflow-x: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+
+  & rux-button::part(container):hover {
+    box-shadow: none;
+  }
+}
+
 /* ALERTS LIST STYLES */
 
 .alert-list-headers {

--- a/src/Components/Alerts/Alerts.css
+++ b/src/Components/Alerts/Alerts.css
@@ -31,7 +31,8 @@
   white-space: nowrap;
   text-overflow: ellipsis;
 
-  & rux-button::part(container):hover {
+  & rux-button::part(container) {
+    padding-inline: var(--spacing-1);
     box-shadow: none;
   }
 }

--- a/src/Components/Alerts/Alerts.tsx
+++ b/src/Components/Alerts/Alerts.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useState } from "react";
 import {
   RuxContainer,
   RuxSelect,
@@ -11,7 +11,6 @@ import type { Category, Status } from "@astrouxds/mock-data";
 import "./Alerts.css";
 
 const Alerts = () => {
-  const [dataFiltered, setDataFiltered] = useState(false);
   const [severitySelection, setSeveritySelection] = useState<Status | "all">(
     "all"
   );
@@ -25,16 +24,9 @@ const Alerts = () => {
   const anySelected = anyAlertsHaveProp("selected", true);
   const deleteSelectedAlerts = () => deleteAlertsWithProp("selected", true);
 
-  useEffect(() => {
-    setDataFiltered(false);
-    if (severitySelection !== "all" || categorySelection !== "all")
-      setDataFiltered(true);
-  }, [severitySelection, categorySelection]);
-
   const handleClearFilter = () => {
     setSeveritySelection("all");
     setCategorySelection("all");
-    setDataFiltered(false);
   };
 
   return (
@@ -71,7 +63,10 @@ const Alerts = () => {
           </RuxSelect>
         </div>
       </div>
-      <div className="filter-notification" hidden={!dataFiltered}>
+      <div
+        className="filter-notification"
+        hidden={severitySelection === "all" && categorySelection === "all"}
+      >
         One or more filters selected.
         <RuxButton
           onClick={handleClearFilter}

--- a/src/Components/Alerts/Alerts.tsx
+++ b/src/Components/Alerts/Alerts.tsx
@@ -4,7 +4,6 @@ import {
   RuxSelect,
   RuxOption,
   RuxButton,
-  RuxNotification,
 } from "@astrouxds/react";
 import AlertsList from "./AlertsList";
 import { useTTCGRMActions, useTTCGRMAlerts } from "@astrouxds/mock-data";
@@ -12,7 +11,7 @@ import type { Category, Status } from "@astrouxds/mock-data";
 import "./Alerts.css";
 
 const Alerts = () => {
-  const [openBanner, setOpenBanner] = useState(false);
+  const [dataFiltered, setDataFiltered] = useState(false);
   const [severitySelection, setSeveritySelection] = useState<Status | "all">(
     "all"
   );
@@ -27,15 +26,15 @@ const Alerts = () => {
   const deleteSelectedAlerts = () => deleteAlertsWithProp("selected", true);
 
   useEffect(() => {
-    setOpenBanner(false);
+    setDataFiltered(false);
     if (severitySelection !== "all" || categorySelection !== "all")
-      setOpenBanner(true);
+      setDataFiltered(true);
   }, [severitySelection, categorySelection]);
 
   const handleClearFilter = () => {
     setSeveritySelection("all");
     setCategorySelection("all");
-    setOpenBanner(false);
+    setDataFiltered(false);
   };
 
   return (
@@ -72,7 +71,7 @@ const Alerts = () => {
           </RuxSelect>
         </div>
       </div>
-      <RuxNotification open={openBanner} small hide-close>
+      <div className="filter-notification" hidden={!dataFiltered}>
         One or more filters selected.
         <RuxButton
           onClick={handleClearFilter}
@@ -83,7 +82,7 @@ const Alerts = () => {
           Clear filters
         </RuxButton>
         to display all alerts.
-      </RuxNotification>
+      </div>
       <AlertsList
         severitySelection={severitySelection}
         categorySelection={categorySelection}


### PR DESCRIPTION
There's not really an official recommendation here, and Notification Banner may well be the way to go here, but I made a small stylistic change here to make the filter notification fall more inline with the way rux-log does it. Absolutely feel free to deny this.