### PR TITLE
fix(gsb): monitoring icons hover state and blue text removed

### DIFF
--- a/src/Components/GlobalStatusBar.css
+++ b/src/Components/GlobalStatusBar.css
@@ -6,18 +6,6 @@
   margin-inline: var(--spacing-3);
 }
 
-.status-indicators rux-monitoring-icon:hover {
-  background-color: var(--color-background-surface-hover);
-}
-
-.status-indicators rux-monitoring-icon::part(monitoring-label) {
-  color: var(--color-text-interactive-default)
-}
-
-.status-indicators rux-monitoring-icon::part(monitoring-label):hover {
-  color: var(--color-text-interactive-hover)
-}
-
 .app-icon-pop-up {
   height: calc(var(--spacing-14, 3.5rem) + var(--spacing-050, 0.125rem));
 }


### PR DESCRIPTION
This fix removes the background color hover state and the blue text from the label, in accordance with other fixes in the demo apps for interactive monitoring icons.
[JIRA Ticket](https://rocketcom.atlassian.net/browse/DEMO-247)