### PR TITLE
DEMO-257 - fix: adding caret hover state to constellation table

### DIFF
--- a/src/Components/Constellation/Constellation.css
+++ b/src/Components/Constellation/Constellation.css
@@ -53,11 +53,6 @@
 
 /* TIMELINE STYLES */
 
-/* .constellation rux-time-region::part(container) {
-  margin: 3px;
-  border: 1px solid var(--color-border-interactive-muted);
-} */
-
 .constellation rux-timeline {
   height: 100%;
   overflow: auto;

--- a/src/Components/Constellation/Constellation.css
+++ b/src/Components/Constellation/Constellation.css
@@ -30,6 +30,18 @@
   visibility: hidden;
 }
 
+.constellation rux-table-header-row rux-table-header-cell:hover rux-icon {
+  visibility: visible;
+}
+
+.constellation rux-table-header-row rux-table-header-cell:hover {
+  cursor: pointer;
+}
+
+.constellation rux-table-header-row rux-table-header-cell:last-child:hover {
+  cursor: text;
+}
+
 .constellation rux-table-cell:last-of-type rux-icon {
   margin-inline: 1rem;
   cursor: pointer;

--- a/src/Components/Constellation/ConstellationList.tsx
+++ b/src/Components/Constellation/ConstellationList.tsx
@@ -32,13 +32,14 @@ const ConstellationList = ({
 }: PropTypes) => {
   const [sortDirection, setSortDirection] = useState<SortDirection>("ASC");
   const [sortProp, setSortProp] = useState<keyof Contact>("id");
-  const [sortedContactIds, setSortedContactIds] = useState<string[]>(contactIds);
-  const [activeHeader, setActiveHeader] = useState<keyof Contact>()
+  const [sortedContactIds, setSortedContactIds] =
+    useState<string[]>(contactIds);
+  const [activeHeader, setActiveHeader] = useState<keyof Contact>();
 
   const handleClick = (event: any) => {
     const target = event.currentTarget as HTMLElement;
     const sortProperty = target.dataset.sortprop as keyof Contact;
-    setActiveHeader(sortProperty)
+    setActiveHeader(sortProperty);
     if (sortProperty === sortProp) {
       // clicked same currently sorted column
       if (sortDirection === "ASC") {
@@ -96,7 +97,6 @@ const ConstellationList = ({
     );
     setSortedContactIds(newSortedContactIds);
   };
-
   const popupMenuHandler = (e: MouseEvent<HTMLSpanElement>) => {
     e.stopPropagation();
     addToast("This feature has not been implemented.", false, 3000);
@@ -111,7 +111,7 @@ const ConstellationList = ({
               <RuxTableHeaderCell data-sortprop="status" onClick={handleClick}>
                 <RuxIcon
                   icon={
-                    (sortDirection === 'ASC' || activeHeader !== 'status')
+                    sortDirection === "ASC" || activeHeader !== "status"
                       ? "arrow-drop-down"
                       : "arrow-drop-up"
                   }
@@ -123,10 +123,10 @@ const ConstellationList = ({
                 data-sortprop="satellite"
                 onClick={handleClick}
               >
-                Satellite
+                <span>Satellite</span>
                 <RuxIcon
                   icon={
-                    (sortDirection === 'ASC' || activeHeader !== 'satellite')
+                    sortDirection === "ASC" || activeHeader !== "satellite"
                       ? "arrow-drop-down"
                       : "arrow-drop-up"
                   }
@@ -139,10 +139,10 @@ const ConstellationList = ({
                 onClick={handleClick}
                 className="text-align-right"
               >
-                Next Pass
+                <span>Next Pass</span>
                 <RuxIcon
                   icon={
-                    (sortDirection === 'ASC' || activeHeader !== 'rev')
+                    sortDirection === "ASC" || activeHeader !== "rev"
                       ? "arrow-drop-down"
                       : "arrow-drop-up"
                   }
@@ -155,10 +155,10 @@ const ConstellationList = ({
                 data-sortprop="aos"
                 onClick={handleClick}
               >
-                AOS
+                <span>AOS</span>
                 <RuxIcon
                   icon={
-                    (sortDirection === 'ASC' || activeHeader !== 'aos')
+                    sortDirection === "ASC" || activeHeader !== "aos"
                       ? "arrow-drop-down"
                       : "arrow-drop-up"
                   }
@@ -171,10 +171,10 @@ const ConstellationList = ({
                 data-sortprop="los"
                 onClick={handleClick}
               >
-                LOS
+                <span>LOS</span>
                 <RuxIcon
                   icon={
-                    (sortDirection === 'ASC' || activeHeader !== 'los')
+                    sortDirection === "ASC" || activeHeader !== "los"
                       ? "arrow-drop-down"
                       : "arrow-drop-up"
                   }
@@ -185,7 +185,7 @@ const ConstellationList = ({
               <RuxTableHeaderCell data-sortprop="status" onClick={handleClick}>
                 <RuxIcon
                   icon={
-                    (sortDirection === 'ASC' || activeHeader !== 'status')
+                    sortDirection === "ASC" || activeHeader !== "status"
                       ? "arrow-drop-down"
                       : "arrow-drop-up"
                   }
@@ -195,10 +195,10 @@ const ConstellationList = ({
                 />
               </RuxTableHeaderCell>
               <RuxTableHeaderCell data-sortprop="ground" onClick={handleClick}>
-                Ground Station
+                <span>Ground Station</span>
                 <RuxIcon
                   icon={
-                    (sortDirection === 'ASC' || activeHeader !== 'ground')
+                    sortDirection === "ASC" || activeHeader !== "ground"
                       ? "arrow-drop-down"
                       : "arrow-drop-up"
                   }
@@ -211,10 +211,10 @@ const ConstellationList = ({
                 onClick={handleClick}
                 className="text-align-right"
               >
-                Azimuth
+                <span>Azimuth</span>
                 <RuxIcon
                   icon={
-                    (sortDirection === 'ASC' || activeHeader !== 'azimuth')
+                    sortDirection === "ASC" || activeHeader !== "azimuth"
                       ? "arrow-drop-down"
                       : "arrow-drop-up"
                   }
@@ -227,10 +227,10 @@ const ConstellationList = ({
                 onClick={handleClick}
                 className="text-align-right"
               >
-                Elevation
+                <span>Elevation</span>
                 <RuxIcon
                   icon={
-                    (sortDirection === 'ASC' || activeHeader !== 'elevation')
+                    sortDirection === "ASC" || activeHeader !== "elevation"
                       ? "arrow-drop-down"
                       : "arrow-drop-up"
                   }
@@ -239,10 +239,10 @@ const ConstellationList = ({
                 />
               </RuxTableHeaderCell>
               <RuxTableHeaderCell data-sortprop="state" onClick={handleClick}>
-                State
+                <span>State</span>
                 <RuxIcon
                   icon={
-                    (sortDirection === 'ASC' || activeHeader !== 'state')
+                    sortDirection === "ASC" || activeHeader !== "state"
                       ? "arrow-drop-down"
                       : "arrow-drop-up"
                   }

--- a/src/Components/Constellation/ConstellationList.tsx
+++ b/src/Components/Constellation/ConstellationList.tsx
@@ -32,12 +32,13 @@ const ConstellationList = ({
 }: PropTypes) => {
   const [sortDirection, setSortDirection] = useState<SortDirection>("ASC");
   const [sortProp, setSortProp] = useState<keyof Contact>("id");
-  const [sortedContactIds, setSortedContactIds] =
-    useState<string[]>(contactIds);
+  const [sortedContactIds, setSortedContactIds] = useState<string[]>(contactIds);
+  const [activeHeader, setActiveHeader] = useState<keyof Contact>()
 
   const handleClick = (event: any) => {
     const target = event.currentTarget as HTMLElement;
     const sortProperty = target.dataset.sortprop as keyof Contact;
+    setActiveHeader(sortProperty)
     if (sortProperty === sortProp) {
       // clicked same currently sorted column
       if (sortDirection === "ASC") {
@@ -110,7 +111,7 @@ const ConstellationList = ({
               <RuxTableHeaderCell data-sortprop="status" onClick={handleClick}>
                 <RuxIcon
                   icon={
-                    sortDirection === "ASC"
+                    (sortDirection === 'ASC' || activeHeader !== 'status')
                       ? "arrow-drop-down"
                       : "arrow-drop-up"
                   }
@@ -125,7 +126,7 @@ const ConstellationList = ({
                 Satellite
                 <RuxIcon
                   icon={
-                    sortDirection === "ASC"
+                    (sortDirection === 'ASC' || activeHeader !== 'satellite')
                       ? "arrow-drop-down"
                       : "arrow-drop-up"
                   }
@@ -141,7 +142,7 @@ const ConstellationList = ({
                 Next Pass
                 <RuxIcon
                   icon={
-                    sortDirection === "ASC"
+                    (sortDirection === 'ASC' || activeHeader !== 'rev')
                       ? "arrow-drop-down"
                       : "arrow-drop-up"
                   }
@@ -157,7 +158,7 @@ const ConstellationList = ({
                 AOS
                 <RuxIcon
                   icon={
-                    sortDirection === "ASC"
+                    (sortDirection === 'ASC' || activeHeader !== 'aos')
                       ? "arrow-drop-down"
                       : "arrow-drop-up"
                   }
@@ -173,7 +174,7 @@ const ConstellationList = ({
                 LOS
                 <RuxIcon
                   icon={
-                    sortDirection === "ASC"
+                    (sortDirection === 'ASC' || activeHeader !== 'los')
                       ? "arrow-drop-down"
                       : "arrow-drop-up"
                   }
@@ -184,7 +185,7 @@ const ConstellationList = ({
               <RuxTableHeaderCell data-sortprop="status" onClick={handleClick}>
                 <RuxIcon
                   icon={
-                    sortDirection === "ASC"
+                    (sortDirection === 'ASC' || activeHeader !== 'status')
                       ? "arrow-drop-down"
                       : "arrow-drop-up"
                   }
@@ -197,7 +198,7 @@ const ConstellationList = ({
                 Ground Station
                 <RuxIcon
                   icon={
-                    sortDirection === "ASC"
+                    (sortDirection === 'ASC' || activeHeader !== 'ground')
                       ? "arrow-drop-down"
                       : "arrow-drop-up"
                   }
@@ -213,7 +214,7 @@ const ConstellationList = ({
                 Azimuth
                 <RuxIcon
                   icon={
-                    sortDirection === "ASC"
+                    (sortDirection === 'ASC' || activeHeader !== 'azimuth')
                       ? "arrow-drop-down"
                       : "arrow-drop-up"
                   }
@@ -229,7 +230,7 @@ const ConstellationList = ({
                 Elevation
                 <RuxIcon
                   icon={
-                    sortDirection === "ASC"
+                    (sortDirection === 'ASC' || activeHeader !== 'elevation')
                       ? "arrow-drop-down"
                       : "arrow-drop-up"
                   }
@@ -241,7 +242,7 @@ const ConstellationList = ({
                 State
                 <RuxIcon
                   icon={
-                    sortDirection === "ASC"
+                    (sortDirection === 'ASC' || activeHeader !== 'state')
                       ? "arrow-drop-down"
                       : "arrow-drop-up"
                   }


### PR DESCRIPTION
This PR has the caret header sorting styles for the constellation table. I did not port over a lot of the markup changes as the table scrolls, so they are not needed to make the sorting caret match the other apps and match the desired pattern.